### PR TITLE
Fix entrypoint: use printenv for hyphenated INPUT_* vars

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,15 +2,27 @@
 set -euo pipefail
 cd "${GITHUB_WORKSPACE:-/github/workspace}"
 
+# GitHub Actions passes Docker action inputs with hyphens preserved in the env
+# var name (e.g. INPUT_OUTPUT-SVG), not converted to underscores. Bash cannot
+# reference hyphenated var names with ${} syntax, so we use printenv.
+hosts="$(printenv INPUT_HOSTS || true)"
+after="$(printenv INPUT_AFTER || true)"
+username="$(printenv INPUT_USERNAME || true)"
+password="$(printenv INPUT_PASSWORD || true)"
+output_svg="$(printenv 'INPUT_OUTPUT-SVG' || true)"
+output_md="$(printenv 'INPUT_OUTPUT-MD' || true)"
+svg_theme="$(printenv 'INPUT_SVG-THEME' || true)"
+svg_multi_color="$(printenv 'INPUT_SVG-MULTI-COLOR' || true)"
+
 args=(--owner "${INPUT_OWNER}")
 
-[[ -n "${INPUT_HOSTS:-}"             ]] && args+=(--hosts          "${INPUT_HOSTS}")
-[[ -n "${INPUT_AFTER:-}"             ]] && args+=(--after          "${INPUT_AFTER}")
-[[ -n "${INPUT_USERNAME:-}"          ]] && args+=(--username       "${INPUT_USERNAME}")
-[[ -n "${INPUT_PASSWORD:-}"          ]] && args+=(--password       "${INPUT_PASSWORD}")
-[[ -n "${INPUT_OUTPUT_SVG:-}"        ]] && args+=(--output-svg     "${INPUT_OUTPUT_SVG}")
-[[ -n "${INPUT_OUTPUT_MD:-}"         ]] && args+=(--output-md      "${INPUT_OUTPUT_MD}")
-[[ -n "${INPUT_SVG_THEME:-}"         ]] && args+=(--svg-theme      "${INPUT_SVG_THEME}")
-[[ "${INPUT_SVG_MULTI_COLOR:-false}" == "true" ]] && args+=(--svg-multi-color)
+[[ -n "$hosts"         ]] && args+=(--hosts          "$hosts")
+[[ -n "$after"         ]] && args+=(--after           "$after")
+[[ -n "$username"      ]] && args+=(--username        "$username")
+[[ -n "$password"      ]] && args+=(--password        "$password")
+[[ -n "$output_svg"    ]] && args+=(--output-svg      "$output_svg")
+[[ -n "$output_md"     ]] && args+=(--output-md       "$output_md")
+[[ -n "$svg_theme"     ]] && args+=(--svg-theme       "$svg_theme")
+[[ "$svg_multi_color" == "true" ]] && args+=(--svg-multi-color)
 
 exec /usr/local/bin/gerritoscopy "${args[@]}"


### PR DESCRIPTION
## Problem

GitHub Actions passes Docker action inputs with **hyphens preserved** in the env var name — e.g. `INPUT_OUTPUT-SVG`, not `INPUT_OUTPUT_SVG`. Bash cannot reference hyphenated variable names with `${}` syntax, so those values were silently empty and `--output-svg` was never passed to the binary.

The ASCII terminal report still printed (it goes to stdout regardless), but no SVG file was written, so `git-auto-commit-action` found nothing to commit.

## Fix

Read the hyphenated env vars via `printenv 'INPUT_OUTPUT-SVG'` etc., store them in local bash variables, then build the arg array from those.

## Test plan

- [ ] Re-run the profile repo action after this image is built — `wrote gerrit-heatmap.svg` should appear in the step log
- [ ] `git-auto-commit-action` commits the file

🤖 Generated with [Claude Code](https://claude.com/claude-code)